### PR TITLE
Update requirement for googletrans to 3.1.0a0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-googletrans = "==2.3.0"
+googletrans = "==3.1.0a0"
 polib = "==1.1.0"
 click = ">=6.0"
 "path.py" = "==11.0.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-googletrans==2.3.0
+googletrans==3.1.0a0
 polib==1.1.0
 Click>=6.0
 path.py==11.5.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,5 +13,5 @@ pytest==3.9.3
 pytest-runner==4.2
 https://github.com/SekouD/potranslator/raw/dev/dependecy_wheels/importlib_resources-1.0.1-py2.py3-none-any.whl
 
-googletrans==2.3.0
+googletrans==3.1.0a0
 polib==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = ['Click>=6.0',
-                'googletrans==2.3.0',
+                'googletrans==3.1.0a0',
                 'polib==1.1.0',
                 'path.py==11.0.1',
                 'importlib_resources==1.0.1',
@@ -32,7 +32,7 @@ test_requirements = ['pip==10.0.1',
                      'coverage==4.5.1',
                      'Sphinx==1.7.6',
                      'twine==1.11.0',
-                     'googletrans==2.3.0',
+                     'googletrans==3.1.0a0',
                      'polib==1.1.0',
                      'importlib_resources==1.0.1',
                      ]


### PR DESCRIPTION
Thanks for the great tool.
Currently the version of googletrans is failing on:
```
site-packages/googletrans/gtoken.py", line 62, in _update
    code = self.RE_TKK.search(r.text).group(1).replace('var ', '')
AttributeError: 'NoneType' object has no attribute 'group'
```
This PR update the required version for google trans to 3.1.0a0

Will it be possible to allow issues on your repository ?